### PR TITLE
Adding `license_expression` and `license_files` serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ repository = "https://github.com/PyO3/pyproject-toml-rs.git"
 
 [dependencies]
 serde = { version = "1.0.125", features = ["derive"] }
-toml = "0.5.8"
+toml_edit = { version = "0.13.4", features = ["easy"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,8 +132,8 @@ pub struct Contact {
 
 impl PyProjectToml {
     /// Parse `pyproject.toml` content
-    pub fn new(content: &str) -> Result<Self, toml::de::Error> {
-        toml::from_str(content)
+    pub fn new(content: &str) -> Result<Self, toml_edit::de::Error> {
+        toml_edit::de::from_str(content)
     }
 }
 


### PR DESCRIPTION
Adds `license_expression` and `license_files` to the pyproject matadata specified in [PEP 639 Core Metadata](https://peps.python.org/pep-0639/#id1). No validation is performed as that should be handled by consumers. Also adds default value for `license_files` as described in PEP 639.

Though the `paths` and `globs` are mutually exclusive through validation, serialization allows them both to be specified. I could not find a way to restrict this via the toml-rs serializer. I think there is a bug in the dotted key handling.