### PR TITLE
Preserve order in hashmap-backed data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ repository = "https://github.com/PyO3/pyproject-toml-rs.git"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+indexmap = { version = "1.9.2", features = ["serde-1"] }
 serde = { version = "1.0.125", features = ["derive"] }
 toml = { version = "0.7.0", default-features = false, features = ["parse"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 /// The `[build-system]` section of a pyproject.toml as specified in PEP 517
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -52,17 +52,17 @@ pub struct Project {
     /// Trove classifiers which apply to the project
     pub classifiers: Option<Vec<String>>,
     /// A table of URLs where the key is the URL label and the value is the URL itself
-    pub urls: Option<HashMap<String, String>>,
+    pub urls: Option<IndexMap<String, String>>,
     /// Entry points
-    pub entry_points: Option<HashMap<String, HashMap<String, String>>>,
+    pub entry_points: Option<IndexMap<String, IndexMap<String, String>>>,
     /// Corresponds to the console_scripts group in the core metadata
-    pub scripts: Option<HashMap<String, String>>,
+    pub scripts: Option<IndexMap<String, String>>,
     /// Corresponds to the gui_scripts group in the core metadata
-    pub gui_scripts: Option<HashMap<String, String>>,
+    pub gui_scripts: Option<IndexMap<String, String>>,
     /// Project dependencies
     pub dependencies: Option<Vec<String>>,
     /// Optional dependencies
-    pub optional_dependencies: Option<HashMap<String, Vec<String>>>,
+    pub optional_dependencies: Option<IndexMap<String, Vec<String>>>,
     /// Specifies which fields listed by PEP 621 were intentionally unspecified
     /// so another tool can/will provide such metadata dynamically.
     pub dynamic: Option<Vec<String>>,


### PR DESCRIPTION
Closes #5

Looking at the `toml` source, it looks like `Map` is implemented with `IndexMap` to preserve order. `Map<String, Value>` implements the Serialize and Deserialize traits. My first thought would be to use this since it's already a `pyproject-toml` dependency and is public.

I don't believe other variants of `Map` implement the traits. So I'll open this as a draft and look into getting the rest of the data backed by `Map` or something similar.

Let me know if you'd like to do this differently. I'd think `Value` may introduce more change than originally expected.