### PR TITLE
Add `#[derive(PartialEq, Eq)]` and `Project::new`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,8 @@ pub struct Project {
 }
 
 impl Project {
-    /// Like `#[derive(Default)]`, but `name` is mandatory in PEP 621
-    pub fn default_with_name(name: String) -> Self {
+    /// Initializes the only field mandatory in PEP 621 (`name`) and leaves everything else empty
+    pub fn new(name: String) -> Self {
         Self {
             name,
             version: None,


### PR DESCRIPTION
We have `#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]` on our PyProject type that we compare with `assert_eq!` in the tests, so we also need those derives here.

Also added `Project::default_with_name` as a way to avoid boilerplate in downstream crates.