### PR TITLE
Apply serde's renaming to the members of ReadMe::Table as well

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ pub enum ReadMe {
     /// Relative path to a text file containing the full description
     RelativePath(String),
     /// Detailed readme information
+    #[serde(rename_all = "kebab-case")]
     Table {
         /// A relative path to a file containing the full description
         file: Option<String>,
@@ -361,6 +362,29 @@ name = "spam"
                 "NOTICE*".to_owned(),
                 "AUTHORS*".to_owned(),
             ]))
+        );
+    }
+
+    #[test]
+    fn test_parse_pyproject_toml_readme_content_type() {
+        let source = r#"[build-system]
+requires = ["maturin"]
+build-backend = "maturin"
+
+[project]
+name = "spam"
+readme = {text = "ReadMe!", content-type = "text/plain"}
+"#;
+        let project_toml = PyProjectToml::new(source).unwrap();
+        let project = project_toml.project.as_ref().unwrap();
+
+        assert_eq!(
+            project.readme,
+            Some(ReadMe::Table {
+                file: None,
+                text: Some("ReadMe!".to_string()),
+                content_type: Some("text/plain".to_string())
+            })
         );
     }
 }


### PR DESCRIPTION
Serde's enum attributes don't apply to individual fields in variants.

See also https://github.com/serde-rs/serde/issues/1061.
