### PR TITLE
Update to latest PEP 639 draft

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "pyproject-toml"
-version = "0.5.2"
+version = "0.6.0"
 description = "pyproject.toml parser in Rust"
 edition = "2021"
 license = "MIT"
-keywords = ["pyproject", "pep517", "pep518", "pep621"]
+keywords = ["pyproject", "pep517", "pep518", "pep621", "pep639"]
 readme = "README.md"
 repository = "https://github.com/PyO3/pyproject-toml-rs.git"
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.6.0
+
+ * Update to latest [PEP 639](https://peps.python.org/pep-0639) draft. The `license` key is now an enum that can either be an SPDX identifier or the previous table form, which accepting PEP 639 would deprecate. The previous implementation of a `project.license-expression` key in `pyproject.toml` has been [removed](https://peps.python.org/pep-0639/#define-a-new-top-level-license-expression-key).


### PR DESCRIPTION
Update to latest [PEP 639](https://peps.python.org/pep-0639) draft. The `license` key is now an enum that can either be an SPDX identifier or the previous table form, which accepting PEP 639 would deprecate. The previous implementation of a `project.license-expression` key in `pyproject.toml` has been [removed](https://peps.python.org/pep-0639/#define-a-new-top-level-license-expression-key).