### PR TITLE
Make the `build_system` table optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyproject-toml"
-version = "0.7.0"
+version = "0.8.0"
 description = "pyproject.toml parser in Rust"
 edition = "2021"
 license = "MIT"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0
+
+ * The `build_system` table is now optional. There are many projects that use pyproject.toml for tool configuration without specifying a build backend, which this change reflects.
+
 ## 0.6.0
 
  * Update to latest [PEP 639](https://peps.python.org/pep-0639) draft. The `license` key is now an enum that can either be an SPDX identifier or the previous table form, which accepting PEP 639 would deprecate. The previous implementation of a `project.license-expression` key in `pyproject.toml` has been [removed](https://peps.python.org/pep-0639/#define-a-new-top-level-license-expression-key).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub struct BuildSystem {
 #[serde(rename_all = "kebab-case")]
 pub struct PyProjectToml {
     /// Build-related data
-    pub build_system: BuildSystem,
+    pub build_system: Option<BuildSystem>,
     /// Project metadata
     pub project: Option<Project>,
 }
@@ -229,7 +229,7 @@ spam-gui = "spam:main_gui"
 [project.entry-points."spam.magical"]
 tomatoes = "spam:main_tomatoes""#;
         let project_toml = PyProjectToml::new(source).unwrap();
-        let build_system = &project_toml.build_system;
+        let build_system = &project_toml.build_system.unwrap();
         assert_eq!(
             build_system.requires,
             &[Requirement::from_str("maturin").unwrap()]


### PR DESCRIPTION
There are many projects that use pyproject.toml for tool configuration without specifying a build backend, which this change reflects.

I checked and this change doesn't affect maturin.