### PR TITLE
update all dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ rust-version = "1.64"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-indexmap = { version = "2.0.0", features = ["serde"] }
-serde = { version = "1.0.125", features = ["derive"] }
-toml = { version = "0.8.0", default-features = false, features = ["parse"] }
-pep508_rs = { version = "0.2.1", features = ["serde"] }
+indexmap = { version = "2.2.2", features = ["serde"] }
+serde = { version = "1.0.196", features = ["derive"] }
+toml = { version = "0.8.10", default-features = false, features = ["parse"] }
+pep508_rs = { version = "0.3.0", features = ["serde"] }
 pep440_rs = { version = "0.4.0", features = ["serde"] }


### PR DESCRIPTION
We're trying to use the latest versions of the `pep*` crates in `rip` (https://github.com/prefix-dev/rip) but there are unfortunate conflicts when resolving different versions of `pep508_rs`.