### PR TITLE
Allow parsing the tool table

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,27 @@ impl<T: DeserializeOwned> PyProjectToml<T> {
     pub fn new(content: &str) -> Result<Self, toml::de::Error> {
         toml::de::from_str(content)
     }
+
+    pub fn try_from(value: PyProjectToml<Table>) -> Result<Self, toml::de::Error> {
+        Ok(Self {
+            build_system: value.build_system,
+            project: value.project,
+            tool: value.tool.map(Table::try_into).transpose()?,
+        })
+    }
+}
+
+impl PyProjectToml {
+    pub fn try_into<'de, T>(self) -> Result<PyProjectToml<T>, toml::de::Error>
+    where
+        T: Deserialize<'de>,
+    {
+        Ok(PyProjectToml {
+            build_system: self.build_system,
+            project: self.project,
+            tool: self.tool.map(Table::try_into).transpose()?,
+        })
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
closes #11 

I wasn't sure how to use the default generic value when calling the constructor in the existing tests, so I had to change them. If this  can be done without change I'm happy to learn!