### PR TITLE
Add an initial implementation of PEP 735 Dependency Groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "pyproject-toml"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "indexmap",
  "pep440_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyproject-toml"
-version = "0.11.0"
+version = "0.12.0"
 description = "pyproject.toml parser in Rust"
 edition = "2021"
 license = "MIT"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0
+
+* Support dependency groups (PEP 735)
+
 ## 0.11.0
 
 * Update pep440_rs to 0.6.0


### PR DESCRIPTION
resolves #23

This initial implementation takes the form of
- treating the `dependency-groups` table as a `Map<String, Vec<DependencyGroupSpecifier>>`
- defining `DependencyGroupSpecifier` as a string or an include

---

There are a couple of points I'm not certain about. Although I would be amenable to changing these, I might have to defer to someone more expert, as my Rust is pretty weak.

I don't know if it's satisfactory for the table to be defined as a type alias? It seemed like the best fit, but I'm not sure if there's a better way of doing this.

This is within the `SHOULD`/`MAY` bounds of the spec, in that tools are allowed to load and validate all of the data eagerly, but the spec also explicitly prefers lazy validation of the table contents.
There are a few ways I thought it might be possible to tackle this (e.g., add a branch to the `DependencyGroupSpecifier` enum for a `Map<String, toml::Value>`), but ultimately it feels like a good fit for Python and a poor fit for Rust.
Eagerly validating the content just seems to me like the most language-appropriate behavior.
